### PR TITLE
Fix compilation error under Ubuntu 16.04 (Actually WSL) and propably …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 doc:baiduDoc.cpp
-	g++ -g -lcurl baiduDoc.cpp -o doc
+	g++ -g baiduDoc.cpp -lcurl -o doc
 
 clean:
 	rm -rf doc


### PR DESCRIPTION
…other systems.

This is because the curl library linking must be specified AFTER the source files that needs it,
otherwise the required functions won't be pulled from libcurl.